### PR TITLE
settings: persist settings between browser restarts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 __v0.9.5 (unreleased)__
 
+* Settings: persist settings between browser restarts.
+
 * Move `LICENSE.txt` to `src/LICENSE.txt`.
 
 * Change "Store the last X screenshots in temporary browser memory" to

--- a/src/js/background/app.js
+++ b/src/js/background/app.js
@@ -1,4 +1,5 @@
 import Screenshot from './app/screenshot.js';
+import Settings from './app/settings.js';
 import runScript from './app/run-script.js';
 
 const notify = (message, timeout)  => {
@@ -45,8 +46,10 @@ const setCaptureHTML5VideoTemplate = () => {
 setCaptureHTML5VideoTemplate();
 
 export default function() {
-  this.videoSize = "visible";
-  this.maxScreenshots = 4;
+  this.localStorage = window.localStorage;
+  this.settings = new Settings(this);
+  this.videoSize = this.settings.getItem("videoSize");
+  this.maxScreenshots = this.settings.getItem("maxScreenshots");
   this.screenshots = [];
   this.screenshotCount = 0;
 

--- a/src/js/background/app/settings.js
+++ b/src/js/background/app/settings.js
@@ -1,0 +1,21 @@
+export default function(app) {
+  const {localStorage} = app;
+
+  const defaults = {
+    maxScreenshots: 4,
+    videoSize: "visible"
+  };
+
+  const settings = localStorage.getItem('settings') ?
+                   JSON.parse(Object.assign({}, defaults, localStorage.getItem('settings'))) : Object.assign({}, defaults);
+
+  this.getItem = (key) => {
+    return settings[key];
+  };
+
+  this.setItem = (key, value) => {
+    settings[key] = value;
+    app[key] = value;
+    localStorage.setItem('settings', JSON.stringify(settings));
+  };
+}

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -19,10 +19,10 @@ chrome.runtime.getBackgroundPage((page) => {
      at its visible size.
   */
   const vSizeSelect = document.getElementById('video-size');
-  setDefaultOption(vSizeSelect, app.videoSize);
+  setDefaultOption(vSizeSelect, app.settings.getItem('videoSize'));
   vSizeSelect.addEventListener('change', (event) => {
     const option = event.target;
-    app.videoSize = option.value;
+    app.settings.setItem('videoSize', option.value);
   });
 
   /*
@@ -30,7 +30,7 @@ chrome.runtime.getBackgroundPage((page) => {
     browser memory.
   */
   const maxSelect = document.getElementById('max-screenshots');
-  setDefaultOption(maxSelect, app.maxScreenshots.toString())
+  setDefaultOption(maxSelect, String(app.settings.getItem('maxScreenshots')));
   maxSelect.addEventListener('change', (event) => {
     const option = event.target;
     if(option.value < app.maxScreenshots) {
@@ -41,7 +41,7 @@ chrome.runtime.getBackgroundPage((page) => {
         }
       }
     }
-    app.maxScreenshots = Number(option.value);
+    app.settings.setItem('maxScreenshots', Number(option.value));
   });
 
   app.getKeyboardCommands().then((commands) => {


### PR DESCRIPTION
Persist the 'maxScreenshots' and 'videoSize' settings between browser
restarts by storing their value in background page localStorage.